### PR TITLE
When downloading a file with a space, the Content-Disposition header is malformed

### DIFF
--- a/util.inc.php
+++ b/util.inc.php
@@ -508,7 +508,7 @@ function serve_file($fn, $dl, $mime = '')
 		// these are taken from the php documentation (on readfile())
 		header('Content-Description: File Transfer');
 		header('Content-Type: application/octet-stream');
-		header('Content-Disposition: attachment; filename='.basename($fn));
+		header('Content-Disposition: attachment; filename="'.basename($fn).'"');
 		header('Content-Transfer-Encoding: binary');
 	} else {
 		header('Content-Type: '.$mime);


### PR DESCRIPTION
For example content/geocaching/shared/Le robot gardien et la machinerie oubliée.docx is served with the following header:

`Content-Disposition: attachment; filename=Le robot gardien et la machinerie oubliée.docx`

It should be served with:

`Content-Disposition: attachment; filename="Le robot gardien et la machinerie oubliée.docx"`
