### PR TITLE
Temporary disabled E_STRICT

### DIFF
--- a/config.inc.php
+++ b/config.inc.php
@@ -9,7 +9,7 @@
  */
 
 
-// error_reporting(E_ALL);						// see php documentation
+error_reporting(E_ALL & ~E_STRICT);						// see php documentation
 
 // try to include user configuration
 @include('user-config.inc.php');


### PR DESCRIPTION
Currently, the code isn't compliant with PHP strict standards, and will raise on PHP 5.5 strict issues.

Meanwhile it's fixed, we can temporarily discard these errors.
