### PR TITLE
Get rid of array_shift

### DIFF
--- a/common.inc.php
+++ b/common.inc.php
@@ -496,14 +496,14 @@ function resolve_aliases($s, $name = '')
 		$s = str_replace('$PAGE$', implode('.', array_slice(expl('.', $name), 0, 2)), $s);
 		$s = str_replace('$page$', implode('.', array_slice(expl('.', $name), 0, 2)), $s);
 		// pagename
-		$s = str_replace('$PAGENAME$', array_shift(expl('.', $name)), $s);
-		$s = str_replace('$pagename$', array_shift(expl('.', $name)), $s);
+		$s = str_replace('$PAGENAME$', get_first_item(expl('.', $name)), $s);
+		$s = str_replace('$pagename$', get_first_item(expl('.', $name)), $s);
 		// protocol used
 		$s = str_replace('$PROT$', empty($_SERVER['HTTPS']) ? 'http' : 'https', $s);
 		$s = str_replace('$prot$', empty($_SERVER['HTTPS']) ? 'http' : 'https', $s);
 		// revision
-		$s = str_replace('$REV$', array_shift(array_slice(expl('.', $name), 1, 1)), $s);
-		$s = str_replace('$rev$', array_shift(array_slice(expl('.', $name), 1, 1)), $s);
+		$s = str_replace('$REV$', get_first_item(array_slice(expl('.', $name), 1, 1)), $s);
+		$s = str_replace('$rev$', get_first_item(array_slice(expl('.', $name), 1, 1)), $s);
 	}
 	return $s;
 }

--- a/module_download.inc.php
+++ b/module_download.inc.php
@@ -152,7 +152,7 @@ function download_save_state($args)
 {
 	$elem = $args['elem'];
 	$obj = $args['obj'];
-	if (array_shift(elem_classes($elem)) != 'download') {
+	if (get_first_item(elem_classes($elem)) != 'download') {
 		return false;
 	}
 	
@@ -207,8 +207,8 @@ function download_snapshot_symlink($args)
 		return false;
 	}
 	
-	$dest_dir = CONTENT_DIR.'/'.array_shift(expl('.', $obj['name'])).'/shared';
-	$src_file = CONTENT_DIR.'/'.array_shift(expl('.', $args['origin'])).'/shared/'.$obj['download-file'];
+	$dest_dir = CONTENT_DIR.'/'.get_first_item(expl('.', $obj['name'])).'/shared';
+	$src_file = CONTENT_DIR.'/'.get_first_item(expl('.', $args['origin'])).'/shared/'.$obj['download-file'];
 	
 	if (($f = dir_has_same_file($dest_dir, $src_file)) !== false) {
 		$obj['download-file'] = $f;

--- a/module_iframe.inc.php
+++ b/module_iframe.inc.php
@@ -160,7 +160,7 @@ function iframe_save_state($args)
 {
 	$elem = $args['elem'];
 	$obj = $args['obj'];
-	if (array_shift(elem_classes($elem)) != 'iframe') {
+	if (get_first_item(elem_classes($elem)) != 'iframe') {
 		return false;
 	}
 	

--- a/module_image.inc.php
+++ b/module_image.inc.php
@@ -390,7 +390,7 @@ function image_resize($args)
 		return response('Original dimensions are not available', 500);
 	}
 	// set pagename
-	$pn = array_shift(expl('.', $obj['name']));
+	$pn = get_first_item(expl('.', $obj['name']));
 	
 	// resizing might not be necessary at all
 	if (!empty($obj['image-resized-file']) && @intval($obj['image-resized-width']) == $width && @intval($obj['image-resized-height'] == $height)) {
@@ -526,7 +526,7 @@ function image_save_state($args)
 	$elem = $args['elem'];
 	$obj = $args['obj'];
 	// only take responsibility for the element when we are its main class
-	if (array_shift(elem_classes($elem)) != 'image') {
+	if (get_first_item(elem_classes($elem)) != 'image') {
 		return false;
 	}
 	
@@ -571,7 +571,7 @@ function image_serve_resource($args)
 	}
 	// we don't have to care about symlinks here as they are being resolved 
 	// before this hook is called
-	$pn = array_shift(expl('.', $obj['name']));
+	$pn = get_first_item(expl('.', $obj['name']));
 	
 	if (!empty($obj['image-resized-file']) && !$args['dl']) {
 		// we have a resized file and don't want to download the original
@@ -638,8 +638,8 @@ function image_snapshot_symlink($args)
 	// shared directory in page a to the one on page b, this happens in this 
 	// hook
 	
-	$dest_dir = CONTENT_DIR.'/'.array_shift(expl('.', $obj['name'])).'/shared';
-	$src_dir = CONTENT_DIR.'/'.array_shift(expl('.', $args['origin'])).'/shared';
+	$dest_dir = CONTENT_DIR.'/'.get_first_item(expl('.', $obj['name'])).'/shared';
+	$src_dir = CONTENT_DIR.'/'.get_first_item(expl('.', $args['origin'])).'/shared';
 	
 	// we do this for image-file and image-resized-file
 	// .. to add a bit of complexity ;)

--- a/module_page.inc.php
+++ b/module_page.inc.php
@@ -46,7 +46,7 @@ function page_clear_background_img($args)
 	
 	if (!empty($obj['page-background-file'])) {
 		// delete file
-		delete_upload(array('pagename'=>array_shift(expl('.', $args['page'])), 'file'=>$obj['page-background-file'], 'max_cnt'=>1));
+		delete_upload(array('pagename'=>get_first_item(expl('.', $args['page'])), 'file'=>$obj['page-background-file'], 'max_cnt'=>1));
 		// and remove attributes
 		return object_remove_attr(array('name'=>$obj['name'], 'attr'=>array('page-background-file', 'page-background-mime')));
 	} else {
@@ -71,7 +71,7 @@ function page_delete_page($args)
 	// check if there is a background-image
 	if (!empty($obj['page-background-file'])) {
 		// delete it
-		delete_upload(array('pagename'=>array_shift(expl('.', $page)), 'file'=>$obj['page-background-file'], 'max_cnt'=>1));
+		delete_upload(array('pagename'=>get_first_item(expl('.', $page)), 'file'=>$obj['page-background-file'], 'max_cnt'=>1));
 		return true;
 	} else {
 		return false;
@@ -189,7 +189,7 @@ function page_serve_resource($args)
 	if (array_pop(expl('.', $obj['name'])) != 'page') {
 		return false;
 	}
-	$pn = array_shift(expl('.', $obj['name']));
+	$pn = get_first_item(expl('.', $obj['name']));
 	
 	if (!empty($obj['page-background-file'])) {
 		$fn = CONTENT_DIR.'/'.$pn.'/shared/'.$obj['page-background-file'];
@@ -252,7 +252,7 @@ function page_upload($args)
 	if (!$obj['#error']) {
 		$obj = $obj['#data'];
 		if (!empty($obj['page-background-file'])) {
-			delete_upload(array('pagename'=>array_shift(expl('.', $args['page'])), 'file'=>$obj['page-background-file'], 'max_cnt'=>1));
+			delete_upload(array('pagename'=>get_first_item(expl('.', $args['page'])), 'file'=>$obj['page-background-file'], 'max_cnt'=>1));
 		}
 	}
 	

--- a/module_text.inc.php
+++ b/module_text.inc.php
@@ -418,7 +418,7 @@ function text_save_state($args)
 {
 	$elem = $args['elem'];
 	$obj = $args['obj'];
-	if (array_shift(elem_classes($elem)) != 'text') {
+	if (get_first_item(elem_classes($elem)) != 'text') {
 		return false;
 	}
 	

--- a/module_video.inc.php
+++ b/module_video.inc.php
@@ -79,7 +79,7 @@ function video_delete_object($args)
 	
 	load_modules('glue');
 	if (!empty($obj['video-file'])) {
-		$pn = array_shift(expl('.', $obj['name']));
+		$pn = get_first_item(expl('.', $obj['name']));
 		delete_upload(array('pagename'=>$pn, 'file'=>$obj['video-file'], 'max_cnt'=>1));
 	}
 }
@@ -204,7 +204,7 @@ function video_save_state($args)
 {
 	$elem = $args['elem'];
 	$obj = $args['obj'];
-	if (array_shift(elem_classes($elem)) != 'video') {
+	if (get_first_item(elem_classes($elem)) != 'video') {
 		return false;
 	}
 	
@@ -234,7 +234,7 @@ function video_serve_resource($args)
 	}
 	
 	if (!empty($obj['video-file'])) {
-		$pn = array_shift(expl('.', $obj['name']));
+		$pn = get_first_item(expl('.', $obj['name']));
 		if (empty($obj['video-file-mime'])) {
 			$obj['video-file-mime'] = '';
 		}
@@ -252,8 +252,8 @@ function video_snapshot_symlink($args)
 		return false;
 	}
 	
-	$dest_dir = CONTENT_DIR.'/'.array_shift(expl('.', $obj['name'])).'/shared';
-	$src_file = CONTENT_DIR.'/'.array_shift(expl('.', $args['origin'])).'/shared/'.$obj['video-file'];
+	$dest_dir = CONTENT_DIR.'/'.get_first_item(expl('.', $obj['name'])).'/shared';
+	$src_file = CONTENT_DIR.'/'.get_first_item(expl('.', $args['origin'])).'/shared/'.$obj['video-file'];
 	
 	if (($f = dir_has_same_file($dest_dir, $src_file)) !== false) {
 		$obj['video-file'] = $f;

--- a/module_webvideo.inc.php
+++ b/module_webvideo.inc.php
@@ -126,7 +126,7 @@ function webvideo_save_state($args)
 {
 	$elem = $args['elem'];
 	$obj = $args['obj'];
-	if (array_shift(elem_classes($elem)) != 'webvideo') {
+	if (get_first_item(elem_classes($elem)) != 'webvideo') {
 		return false;
 	}
 	

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require __DIR__ . '/../util.inc.php';
+
+class UtilTest extends TestCase
+{
+
+	function testIsIterable()
+	{
+		if (version_compare(PHP_VERSION, '7.1', '>=')) {
+			$this->markTestSkipped("This test is only for PHP 7.1-");
+		}
+
+		$this->assertTrue(is_iterable([4]));
+		$this->assertFalse(is_iterable(4));
+		$this->assertFalse(is_iterable(new \stdClass));
+		$this->assertTrue(is_iterable(new \DirectoryIterator(".")));
+	}
+
+
+	function testGetFirstitem()
+	{
+		$this->assertEquals(4, get_first_item([4]));
+		$this->assertEquals('a', get_first_item(explode('.', 'a.b.c')));
+		$this->assertNull(get_first_item([]));
+	}
+
+
+	/**
+	 * @expectedException \InvalidArgumentException
+	 */
+	function testGetFirstitemWithNonIterable()
+	{
+		get_first_item(new \stdClass);
+	}
+
+}

--- a/util.inc.php
+++ b/util.inc.php
@@ -253,6 +253,24 @@ function filext($s)
 
 
 /**
+ *	select the first element of an array, or other Traversable
+ *
+ *	@param Traversable|array $iterable the array where to pick the first value
+ *	@return mixed
+ */
+function get_first_item($iterable)
+{
+	if (!is_iterable($iterable)) {
+		throw new InvalidArgumentException("Argument isn't iterable.");
+	}
+
+	foreach ($iterable as $item) {
+		return $item;
+	}
+}
+
+
+/**
  *	return a http error message to the client
  *
  *	if $header_only is false (the default), the function doesn't 
@@ -400,6 +418,20 @@ function is_url($s)
 		return true;
 	} else {
 		return false;
+	}
+}
+
+if (!function_exists('is_iterable'))
+{
+	/**
+	 * determine if a variable is iterable (already implemented in PHP 7.1+)
+	 *
+	 * @param mixed $var the variable to check
+	 * @return bool
+	 */
+	function is_iterable($var)
+	{
+		return is_array($var) || $var instanceof Traversable;
 	}
 }
 


### PR DESCRIPTION
The array_shift PHP function expects an array to manipulate,
stored in a variable. As such, it's a poor candidate to get
the first element of an array, as it will raise a strict
exception if we pass it a reference to an array instead.

We supersede array_shift by an universal function to get
the first element of any array or object which implements
the Traversable interface, kicking the iterator to pick
th first element.

Fixes #9.