### PR TITLE
Support for php8

### DIFF
--- a/json.php
+++ b/json.php
@@ -44,9 +44,7 @@ switch ($_SERVER['REQUEST_METHOD']) {
 	//	break;
 	case 'POST':
 		foreach ($_POST as $key=>$val) {
-			if (get_magic_quotes_gpc()) {
-				$val = stripslashes($val);
-			}
+			$val = stripslashes($val);
 			$dec = @json_decode($val, true);
 			if ($dec === NULL) {
 				$err = response('Error decoding the argument '.quot($key).' => '.var_dump_inl($val), 400);


### PR DESCRIPTION
I wanted to run hotglue on my btinami lamp server, and it is running php8.1
To allow the execution, I needed to make this small changes as the verb was deprecated in php8.1.
I have been running this instance for a couple of works without noticing any issue